### PR TITLE
Unnecessary Index Traversal patch 1

### DIFF
--- a/RawCopy.au3
+++ b/RawCopy.au3
@@ -5,7 +5,7 @@
 #AutoIt3Wrapper_Change2CUI=y
 #AutoIt3Wrapper_Res_Comment=Raw file copy
 #AutoIt3Wrapper_Res_Description=Copy files from NTFS volumes by using low level disk access
-#AutoIt3Wrapper_Res_Fileversion=1.0.0.16
+#AutoIt3Wrapper_Res_Fileversion=1.0.0.17
 #AutoIt3Wrapper_Res_LegalCopyright=Joakim Schicht
 #AutoIt3Wrapper_Res_requestedExecutionLevel=asInvoker
 #EndRegion ;**** Directives created by AutoIt3Wrapper_GUI ****
@@ -13,6 +13,7 @@
 #include <Array.au3>
 #Include <String.au3>
 #Include <FileConstants.au3>
+#include <Date.au3>
 ;
 ; https://github.com/jschicht
 ;
@@ -93,13 +94,25 @@ $MFT_RUN_Clusters = $RUN_Clusters
 
 If StringIsDigit($IndexNumber) Then
 	Global $DataQ[1],$AttribX[1],$AttribXType[1],$AttribXCounter[1],$AttribXStreamName[1]
+	ConsoleWrite("_GenRefArray()" & @CRLF)
+	ConsoleWrite(_Now () & "." & _MSec() & @crlf)
 	_GenRefArray()
+	ConsoleWrite(_Now () & "." & _MSec() & @crlf)
 	$RetRec = _FindFileMFTRecord($IndexNumber)
 	If Not IsArray($RetRec) Then Exit
 	$NewRecord = $RetRec[1]
+	ConsoleWrite("_DecodeMFTRecord($NewRecord,1)" & @CRLF)
+	ConsoleWrite(_Now () & "." & _MSec() & @crlf)
 	_DecodeMFTRecord($NewRecord,1)
+	ConsoleWrite(_Now () & "." & _MSec() & @crlf)
+	ConsoleWrite("_DecodeNameQ($NameQ)" & @CRLF)
+	ConsoleWrite(_Now () & "." & _MSec() & @crlf)
 	_DecodeNameQ($NameQ)
+	ConsoleWrite(_Now () & "." & _MSec() & @crlf)
+	ConsoleWrite("_MainExtract()" & @CRLF)
+	ConsoleWrite(_Now () & "." & _MSec() & @crlf)
 	_MainExtract()
+	ConsoleWrite(_Now () & "." & _MSec() & @crlf)
 	ConsoleWrite(@CRLF)
 	_End($Timerstart)
 	Exit
@@ -117,7 +130,7 @@ For $i = 2 To $DirArray[0]
 	If Not IsArray($RetRec) Then Exit
 	$NewRecord = $RetRec[1]
 	_DecodeMFTRecord($NewRecord,1)
-;	ConsoleWrite("Parsing INDX records of Mft ref " & $NextRef & " to find " & $DirArray[$i] & @CRLF)
+	ConsoleWrite("Parsing INDX records of Mft ref " & $NextRef & " to find " & $DirArray[$i] & @CRLF)
 	$NextRef = _ParseIndex($DirArray[$i])
 	$MftRefArray[$i]=$NextRef
 	If @error Then
@@ -152,12 +165,24 @@ For $i = 2 To $DirArray[0]
 Next
 
 Global $DataQ[1],$AttribX[1],$AttribXType[1],$AttribXCounter[1],$AttribXStreamName[1]
+ConsoleWrite("_GenRefArray()" & @CRLF)
+ConsoleWrite(_Now () & "." & _MSec() & @crlf)
 _GenRefArray()
+ConsoleWrite(_Now () & "." & _MSec() & @crlf)
+ConsoleWrite("_FindFileMFTRecord($NextRef)" & @CRLF)
+ConsoleWrite(_Now () & "." & _MSec() & @crlf)
 $RetRec = _FindFileMFTRecord($NextRef)
+ConsoleWrite(_Now () & "." & _MSec() & @crlf)
 If Not IsArray($RetRec) Then Exit
 $NewRecord = $RetRec[1]
+ConsoleWrite("_DecodeMFTRecord($NewRecord,1)" & @CRLF)
+ConsoleWrite(_Now () & "." & _MSec() & @crlf)
 _DecodeMFTRecord($NewRecord,1)
+ConsoleWrite(_Now () & "." & _MSec() & @crlf)
+ConsoleWrite("_MainExtract()" & @CRLF)
+ConsoleWrite(_Now () & "." & _MSec() & @crlf)
 _MainExtract()
+ConsoleWrite(_Now () & "." & _MSec() & @crlf)
 ConsoleWrite(@CRLF)
 _End($Timerstart)
 Exit
@@ -288,9 +313,9 @@ Func _GetIndexNumber($file, $mode)
     $ret = DllCall($hNTDLL, "int", "NtOpenFile", "hwnd*", "", "dword", $GENERIC_READ, "ptr", DllStructGetPtr($sOA), "ptr", DllStructGetPtr($sISB), _
                                 "ulong", $FILE_SHARE_READ, "ulong", BitOR($FILE_MODE, $FILE_RANDOM_ACCESS))
 	If NT_SUCCESS($ret[0]) Then
-;		ConsoleWrite("NtOpenFile: Success" & @CRLF)
+		ConsoleWrite("NtOpenFile: Success" & @CRLF)
 	Else
-;		ConsoleWrite("Error: NtOpenFile returned: 0x" & Hex($ret[0],8) & @CRLF)
+		ConsoleWrite("Error: NtOpenFile returned: 0x" & Hex($ret[0],8) & @CRLF)
 		Return SetError(1,0,"Error: NtOpenFile returned: 0x" & Hex($ret[0],8))
 	EndIf
     Local $hFile = $ret[1]
@@ -302,7 +327,7 @@ Func _GetIndexNumber($file, $mode)
 		Local $sFSO = DllStructCreate($tagFILEINTERNALINFORMATION, $pFSO)
 		Local $IndexNumber = DllStructGetData($sFSO, "IndexNumber")
     Else
-;        ConsoleWrite("Error: NtQueryInformationFile returned: 0x" & Hex($ret[0],8) & @CRLF)
+         ConsoleWrite("Error: NtQueryInformationFile returned: 0x" & Hex($ret[0],8) & @CRLF)
 		Return SetError(1,0,"Error: NtQueryInformationFile returned: 0x" & Hex($ret[0],8))
     EndIf
     $ret = DllCall($hNTDLL, "int", "NtClose", "hwnd", $hFile)
@@ -338,7 +363,7 @@ Func _DecodeAttrList($TargetFile, $AttrList)
 		$size = Dec(_SwapEndian(StringMid($AttrList, $offset*2 + 97, 16)))
 		$offset = ($offset + Dec(_SwapEndian(StringMid($AttrList, $offset*2 + 65, 4))))*2
 		$DataRun = StringMid($AttrList, $offset+1, StringLen($AttrList)-$offset)
-;		ConsoleWrite("Attribute_List DataRun is " & $DataRun & @CRLF)
+ 		ConsoleWrite("Attribute_List DataRun is " & $DataRun & @CRLF)
 		Global $RUN_VCN[1], $RUN_Clusters[1]
 		_ExtractDataRuns()
 		$tBuffer = DllStructCreate("byte[" & $BytesPerCluster & "]")
@@ -357,7 +382,7 @@ Func _DecodeAttrList($TargetFile, $AttrList)
 				$List &= StringTrimLeft(DllStructGetData($tBuffer, 1),2)
 			Next
 		Next
-;		_DebugOut("***AttrList New:",$List)
+		_DebugOut("***AttrList New:",$List)
 		_WinAPI_CloseHandle($hFile)
 		$List = StringMid($List, 1, $size*2)
 	EndIf
@@ -393,7 +418,7 @@ Func _DecodeAttrList($TargetFile, $AttrList)
 		;_DisplayInfo("No extra MFT records found" & @CRLF)
 	Else
 		$AttrQ = StringSplit(StringTrimRight($str,1), "-")
-;		ConsoleWrite("Decode of $ATTRIBUTE_LIST reveiled extra MFT Records to be examined = " & _ArrayToString($AttrQ, @CRLF) & @CRLF)
+		ConsoleWrite("Decode of $ATTRIBUTE_LIST reveiled extra MFT Records to be examined = " & _ArrayToString($AttrQ, @CRLF) & @CRLF)
 	EndIf
 EndFunc
 
@@ -492,12 +517,12 @@ Func _DecodeMFTRecord0($record, $FileRef)      ;produces DataQ
 				$str = ""
 				For $i = 1 To $AttrQ[0]
 					$MftAttrListString &= $AttrQ[$i] & ","
-;					ConsoleWrite("$AttrQ[$i]: " & $AttrQ[$i] & @CRLF)
+					ConsoleWrite("$AttrQ[$i]: " & $AttrQ[$i] & @CRLF)
 					If Not IsNumber(Int($AttrQ[$i])) Then
 						_DebugOut($FileRef & " Overwritten extra record (" & $AttrQ[$i] & ")", $record)
 						Return ""
 					EndIf
-;					ConsoleWrite("$AttrQ[$i]: " & $AttrQ[$i] & @CRLF)
+					ConsoleWrite("$AttrQ[$i]: " & $AttrQ[$i] & @CRLF)
 					$rec = _GetAttrListMFTRecord(($AttrQ[$i]*$MFT_Record_Size)+($LogicalClusterNumberforthefileMFT*$BytesPerCluster))
 					If StringMid($rec,3,8) <> $RecordSignature Then
 						_DebugOut($FileRef & " Bad signature for extra record", $record)
@@ -891,7 +916,7 @@ Func _FindFileMFTRecord($MftRef)
 			ConsoleWrite("	part " & $k & " of record has " & $SplitRecordSize & " bytes at raw offset 0x" & Hex(Int($ImageOffset+$SplitRecordOffset)) & @CRLF)
 			$kBuffer=0
 		Next
-;		ConsoleWrite(_HexEncode($record) & @CRLF)
+		ConsoleWrite(_HexEncode($record) & @CRLF)
 	Else
 		Local $RecordsDivisor = $MFT_Record_Size/512
 		For $i = 1 To UBound($MFT_RUN_Clusters)-1
@@ -915,7 +940,7 @@ Func _FindFileMFTRecord($MftRef)
 		_WinAPI_ReadFile($hFile, DllStructGetPtr($tBuffer), $MFT_Record_Size, $nBytes)
 		$record = DllStructGetData($tBuffer, 1)
 		$TmpOffset = DllCall('kernel32.dll', 'int', 'SetFilePointerEx', 'ptr', $hFile, 'int64', 0, 'int64*', 0, 'dword', 1)
-		;ConsoleWrite("Record number: " & $MftRef & " found at disk offset: " & $TmpOffset[3]-$MFT_Record_Size & " -> 0x" & Hex(Int($TmpOffset[3]-$MFT_Record_Size)) & @CRLF)
+		ConsoleWrite("Record number: " & $MftRef & " found at disk offset: " & $TmpOffset[3]-$MFT_Record_Size & " -> 0x" & Hex(Int($TmpOffset[3]-$MFT_Record_Size)) & @CRLF)
 	EndIf
 
 	If StringMid($record,91,8) = $TargetFile Then
@@ -942,7 +967,7 @@ Func _FindMFT($TargetFile)
 		;_DisplayInfo("Error in function CreateFile when trying to locate MFT: " & _WinAPI_GetLastErrorMessage() & @CRLF)
 		Return SetError(1,0,0)
 	EndIf
-;	ConsoleWrite("$MFT_Offset: " & $MFT_Offset & @CRLF)
+	ConsoleWrite("$MFT_Offset: " & $MFT_Offset & @CRLF)
 	_WinAPI_SetFilePointerEx($hFile, $ImageOffset+$MFT_Offset, $FILE_BEGIN)
 	_WinAPI_ReadFile($hFile, DllStructGetPtr($tBuffer), $MFT_Record_Size, $nBytes)
 	_WinAPI_CloseHandle($hFile)
@@ -953,7 +978,7 @@ Func _FindMFT($TargetFile)
 		Return ""
 	EndIf
 	If StringMid($record,47,4) = "0100" AND Dec(_SwapEndian(StringMid($record,91,8))) = $TargetFile Then
-;		ConsoleWrite("MFT record found" & @CRLF)
+		ConsoleWrite("MFT record found" & @CRLF)
 		Return $record		;returns record for MFT
 	EndIf
 	ConsoleWrite("MFT record not found" & @CRLF)
@@ -1372,20 +1397,20 @@ Func _GetAttributeEntry($Entry)
 	$ATTRIBUTE_HEADER_Length = StringMid($Entry,9,8)
 	$ATTRIBUTE_HEADER_Length = Dec(StringMid($ATTRIBUTE_HEADER_Length,7,2) & StringMid($ATTRIBUTE_HEADER_Length,5,2) & StringMid($ATTRIBUTE_HEADER_Length,3,2) & StringMid($ATTRIBUTE_HEADER_Length,1,2))
 	$ATTRIBUTE_HEADER_NonResidentFlag = StringMid($Entry,17,2)
-;	ConsoleWrite("$ATTRIBUTE_HEADER_NonResidentFlag = " & $ATTRIBUTE_HEADER_NonResidentFlag & @crlf)
+;~ 	ConsoleWrite("$ATTRIBUTE_HEADER_NonResidentFlag = " & $ATTRIBUTE_HEADER_NonResidentFlag & @crlf)
 	$ATTRIBUTE_HEADER_NameLength = Dec(StringMid($Entry,19,2))
-;	ConsoleWrite("$ATTRIBUTE_HEADER_NameLength = " & $ATTRIBUTE_HEADER_NameLength & @crlf)
+;~ 	ConsoleWrite("$ATTRIBUTE_HEADER_NameLength = " & $ATTRIBUTE_HEADER_NameLength & @crlf)
 	$ATTRIBUTE_HEADER_NameRelativeOffset = StringMid($Entry,21,4)
-;	ConsoleWrite("$ATTRIBUTE_HEADER_NameRelativeOffset = " & $ATTRIBUTE_HEADER_NameRelativeOffset & @crlf)
+;~ 	ConsoleWrite("$ATTRIBUTE_HEADER_NameRelativeOffset = " & $ATTRIBUTE_HEADER_NameRelativeOffset & @crlf)
 	$ATTRIBUTE_HEADER_NameRelativeOffset = Dec(_SwapEndian($ATTRIBUTE_HEADER_NameRelativeOffset))
-;	ConsoleWrite("$ATTRIBUTE_HEADER_NameRelativeOffset = " & $ATTRIBUTE_HEADER_NameRelativeOffset & @crlf)
+	ConsoleWrite("$ATTRIBUTE_HEADER_NameRelativeOffset = " & $ATTRIBUTE_HEADER_NameRelativeOffset & @crlf)
 	If $ATTRIBUTE_HEADER_NameLength > 0 Then
 		$ATTRIBUTE_HEADER_Name = _UnicodeHexToStr(StringMid($Entry,$ATTRIBUTE_HEADER_NameRelativeOffset*2 + 1,$ATTRIBUTE_HEADER_NameLength*4))
 	Else
 		$ATTRIBUTE_HEADER_Name = ""
 	EndIf
 	$ATTRIBUTE_HEADER_Flags = _SwapEndian(StringMid($Entry,25,4))
-;	ConsoleWrite("$ATTRIBUTE_HEADER_Flags = " & $ATTRIBUTE_HEADER_Flags & @crlf)
+;~ 	ConsoleWrite("$ATTRIBUTE_HEADER_Flags = " & $ATTRIBUTE_HEADER_Flags & @crlf)
 	$Flags = ""
 	If $ATTRIBUTE_HEADER_Flags = "0000" Then
 		$Flags = "NORMAL"
@@ -1404,63 +1429,63 @@ Func _GetAttributeEntry($Entry)
 		EndIf
 		$Flags = StringTrimRight($Flags,1)
 	EndIf
-;	ConsoleWrite("File is " & $Flags & @CRLF)
+;~ 	ConsoleWrite("File is " & $Flags & @CRLF)
 	$ATTRIBUTE_HEADER_AttributeID = StringMid($Entry,29,4)
 	$ATTRIBUTE_HEADER_AttributeID = StringMid($ATTRIBUTE_HEADER_AttributeID,3,2) & StringMid($ATTRIBUTE_HEADER_AttributeID,1,2)
 	If $ATTRIBUTE_HEADER_NonResidentFlag = '01' Then
 		$ATTRIBUTE_HEADER_StartVCN = StringMid($Entry,33,16)
-;		ConsoleWrite("$ATTRIBUTE_HEADER_StartVCN = " & $ATTRIBUTE_HEADER_StartVCN & @crlf)
+;~ 		ConsoleWrite("$ATTRIBUTE_HEADER_StartVCN = " & $ATTRIBUTE_HEADER_StartVCN & @crlf)
 		$ATTRIBUTE_HEADER_StartVCN = Dec(_SwapEndian($ATTRIBUTE_HEADER_StartVCN),2)
-;		ConsoleWrite("$ATTRIBUTE_HEADER_StartVCN = " & $ATTRIBUTE_HEADER_StartVCN & @crlf)
+;~ 		ConsoleWrite("$ATTRIBUTE_HEADER_StartVCN = " & $ATTRIBUTE_HEADER_StartVCN & @crlf)
 		$ATTRIBUTE_HEADER_LastVCN = StringMid($Entry,49,16)
-;		ConsoleWrite("$ATTRIBUTE_HEADER_LastVCN = " & $ATTRIBUTE_HEADER_LastVCN & @crlf)
+;~ 		ConsoleWrite("$ATTRIBUTE_HEADER_LastVCN = " & $ATTRIBUTE_HEADER_LastVCN & @crlf)
 		$ATTRIBUTE_HEADER_LastVCN = Dec(_SwapEndian($ATTRIBUTE_HEADER_LastVCN),2)
-;		ConsoleWrite("$ATTRIBUTE_HEADER_LastVCN = " & $ATTRIBUTE_HEADER_LastVCN & @crlf)
+;~ 		ConsoleWrite("$ATTRIBUTE_HEADER_LastVCN = " & $ATTRIBUTE_HEADER_LastVCN & @crlf)
 		$ATTRIBUTE_HEADER_VCNs = $ATTRIBUTE_HEADER_LastVCN - $ATTRIBUTE_HEADER_StartVCN
-;		ConsoleWrite("$ATTRIBUTE_HEADER_VCNs = " & $ATTRIBUTE_HEADER_VCNs & @crlf)
+;~ 		ConsoleWrite("$ATTRIBUTE_HEADER_VCNs = " & $ATTRIBUTE_HEADER_VCNs & @crlf)
 		$ATTRIBUTE_HEADER_OffsetToDataRuns = StringMid($Entry,65,4)
 		$ATTRIBUTE_HEADER_OffsetToDataRuns = Dec(StringMid($ATTRIBUTE_HEADER_OffsetToDataRuns,3,1) & StringMid($ATTRIBUTE_HEADER_OffsetToDataRuns,3,1))
 		$ATTRIBUTE_HEADER_CompressionUnitSize = Dec(_SwapEndian(StringMid($Entry,69,4)))
-;		ConsoleWrite("$ATTRIBUTE_HEADER_CompressionUnitSize = " & $ATTRIBUTE_HEADER_CompressionUnitSize & @crlf)
+;~ 		ConsoleWrite("$ATTRIBUTE_HEADER_CompressionUnitSize = " & $ATTRIBUTE_HEADER_CompressionUnitSize & @crlf)
 		$IsCompressed = 0
 		If $ATTRIBUTE_HEADER_CompressionUnitSize = 4 Then $IsCompressed = 1
 		$ATTRIBUTE_HEADER_Padding = StringMid($Entry,73,8)
 		$ATTRIBUTE_HEADER_Padding = StringMid($ATTRIBUTE_HEADER_Padding,7,2) & StringMid($ATTRIBUTE_HEADER_Padding,5,2) & StringMid($ATTRIBUTE_HEADER_Padding,3,2) & StringMid($ATTRIBUTE_HEADER_Padding,1,2)
 		$ATTRIBUTE_HEADER_AllocatedSize = StringMid($Entry,81,16)
-;		ConsoleWrite("$ATTRIBUTE_HEADER_AllocatedSize = " & $ATTRIBUTE_HEADER_AllocatedSize & @crlf)
+;~ 		ConsoleWrite("$ATTRIBUTE_HEADER_AllocatedSize = " & $ATTRIBUTE_HEADER_AllocatedSize & @crlf)
 		$ATTRIBUTE_HEADER_AllocatedSize = Dec(_SwapEndian($ATTRIBUTE_HEADER_AllocatedSize),2)
-;		ConsoleWrite("$ATTRIBUTE_HEADER_AllocatedSize = " & $ATTRIBUTE_HEADER_AllocatedSize & @crlf)
+;~ 		ConsoleWrite("$ATTRIBUTE_HEADER_AllocatedSize = " & $ATTRIBUTE_HEADER_AllocatedSize & @crlf)
 		$ATTRIBUTE_HEADER_RealSize = StringMid($Entry,97,16)
-;		ConsoleWrite("$ATTRIBUTE_HEADER_RealSize = " & $ATTRIBUTE_HEADER_RealSize & @crlf)
+;~ 		ConsoleWrite("$ATTRIBUTE_HEADER_RealSize = " & $ATTRIBUTE_HEADER_RealSize & @crlf)
 		$ATTRIBUTE_HEADER_RealSize = Dec(_SwapEndian($ATTRIBUTE_HEADER_RealSize),2)
-;		ConsoleWrite("$ATTRIBUTE_HEADER_RealSize = " & $ATTRIBUTE_HEADER_RealSize & @crlf)
+;~ 		ConsoleWrite("$ATTRIBUTE_HEADER_RealSize = " & $ATTRIBUTE_HEADER_RealSize & @crlf)
 		$ATTRIBUTE_HEADER_InitializedStreamSize = StringMid($Entry,113,16)
-;		ConsoleWrite("$ATTRIBUTE_HEADER_InitializedStreamSize = " & $ATTRIBUTE_HEADER_InitializedStreamSize & @crlf)
+;~ 		ConsoleWrite("$ATTRIBUTE_HEADER_InitializedStreamSize = " & $ATTRIBUTE_HEADER_InitializedStreamSize & @crlf)
 		$ATTRIBUTE_HEADER_InitializedStreamSize = Dec(_SwapEndian($ATTRIBUTE_HEADER_InitializedStreamSize),2)
-;		ConsoleWrite("$ATTRIBUTE_HEADER_InitializedStreamSize = " & $ATTRIBUTE_HEADER_InitializedStreamSize & @crlf)
+;~ 		ConsoleWrite("$ATTRIBUTE_HEADER_InitializedStreamSize = " & $ATTRIBUTE_HEADER_InitializedStreamSize & @crlf)
 		$RunListOffset = StringMid($Entry,65,4)
-;		ConsoleWrite("$RunListOffset = " & $RunListOffset & @crlf)
+;~ 		ConsoleWrite("$RunListOffset = " & $RunListOffset & @crlf)
 		$RunListOffset = Dec(_SwapEndian($RunListOffset))
-;		ConsoleWrite("$RunListOffset = " & $RunListOffset & @crlf)
+;~ 		ConsoleWrite("$RunListOffset = " & $RunListOffset & @crlf)
 		If $IsCompressed AND $RunListOffset = 72 Then
 			$ATTRIBUTE_HEADER_CompressedSize = StringMid($Entry,129,16)
 			$ATTRIBUTE_HEADER_CompressedSize = Dec(_SwapEndian($ATTRIBUTE_HEADER_CompressedSize),2)
 		EndIf
 		$DataRun = StringMid($Entry,$RunListOffset*2+1,(StringLen($Entry)-$RunListOffset)*2)
-;		ConsoleWrite("$DataRun = " & $DataRun & @crlf)
+;~ 		ConsoleWrite("$DataRun = " & $DataRun & @crlf)
 	ElseIf $ATTRIBUTE_HEADER_NonResidentFlag = '00' Then
 		$ATTRIBUTE_HEADER_LengthOfAttribute = StringMid($Entry,33,8)
-;		ConsoleWrite("$ATTRIBUTE_HEADER_LengthOfAttribute = " & $ATTRIBUTE_HEADER_LengthOfAttribute & @crlf)
+;~ 		ConsoleWrite("$ATTRIBUTE_HEADER_LengthOfAttribute = " & $ATTRIBUTE_HEADER_LengthOfAttribute & @crlf)
 		$ATTRIBUTE_HEADER_LengthOfAttribute = Dec(_SwapEndian($ATTRIBUTE_HEADER_LengthOfAttribute),2)
-;		ConsoleWrite("$ATTRIBUTE_HEADER_LengthOfAttribute = " & $ATTRIBUTE_HEADER_LengthOfAttribute & @crlf)
+;~ 		ConsoleWrite("$ATTRIBUTE_HEADER_LengthOfAttribute = " & $ATTRIBUTE_HEADER_LengthOfAttribute & @crlf)
 ;		$ATTRIBUTE_HEADER_OffsetToAttribute = StringMid($Entry,41,4)
 ;		$ATTRIBUTE_HEADER_OffsetToAttribute = Dec(StringMid($ATTRIBUTE_HEADER_OffsetToAttribute,3,2) & StringMid($ATTRIBUTE_HEADER_OffsetToAttribute,1,2))
 		$ATTRIBUTE_HEADER_OffsetToAttribute = Dec(_SwapEndian(StringMid($Entry,41,4)))
-;		ConsoleWrite("$ATTRIBUTE_HEADER_OffsetToAttribute = " & $ATTRIBUTE_HEADER_OffsetToAttribute & @crlf)
+;~ 		ConsoleWrite("$ATTRIBUTE_HEADER_OffsetToAttribute = " & $ATTRIBUTE_HEADER_OffsetToAttribute & @crlf)
 		$ATTRIBUTE_HEADER_IndexedFlag = Dec(StringMid($Entry,45,2))
 		$ATTRIBUTE_HEADER_Padding = StringMid($Entry,47,2)
 		$DataRun = StringMid($Entry,$ATTRIBUTE_HEADER_OffsetToAttribute*2+1,$ATTRIBUTE_HEADER_LengthOfAttribute*2)
-;		ConsoleWrite("$DataRun = " & $DataRun & @crlf)
+;~ 		ConsoleWrite("$DataRun = " & $DataRun & @crlf)
 	EndIf
 ; Possible continuation
 ;	For $i = 1 To UBound($DataQ) - 1
@@ -1483,14 +1508,14 @@ Func _GetAttributeEntry($Entry)
 			Do
 				$RunListID = StringMid($DataRun,$i,2)
 				If $RunListID = "00" Then ExitLoop
-;				ConsoleWrite("$RunListID = " & $RunListID & @crlf)
+				ConsoleWrite("$RunListID = " & $RunListID & @crlf)
 				$i += 2
 				$RunListClustersLength = Dec(StringMid($RunListID,2,1))
-;				ConsoleWrite("$RunListClustersLength = " & $RunListClustersLength & @crlf)
+				ConsoleWrite("$RunListClustersLength = " & $RunListClustersLength & @crlf)
 				$RunListVCNLength = Dec(StringMid($RunListID,1,1))
-;				ConsoleWrite("$RunListVCNLength = " & $RunListVCNLength & @crlf)
+				ConsoleWrite("$RunListVCNLength = " & $RunListVCNLength & @crlf)
 				$RunListClusters = Dec(_SwapEndian(StringMid($DataRun,$i,$RunListClustersLength*2)),2)
-;				ConsoleWrite("$RunListClusters = " & $RunListClusters & @crlf)
+				ConsoleWrite("$RunListClusters = " & $RunListClusters & @crlf)
 				$i += $RunListClustersLength*2
 				$RunListVCN = _SwapEndian(StringMid($DataRun, $i, $RunListVCNLength*2))
 				;next line handles positive or negative move
@@ -1500,7 +1525,7 @@ Func _GetAttributeEntry($Entry)
 				Else
 					$RunListVCN = 0			;$RUN_VCN[$r-1]		;0
 				EndIf
-;				ConsoleWrite("$RunListVCN = " & $RunListVCN & @crlf)
+				ConsoleWrite("$RunListVCN = " & $RunListVCN & @crlf)
 				If (($RunListVCN=0) And ($RunListClusters>16) And (Mod($RunListClusters,16)>0)) Then
 				;If (($RunListVCN=$RUN_VCN[$r-1]) And ($RunListClusters>16) And (Mod($RunListClusters,16)>0)) Then
 				;may be sparse section at end of Compression Signature
@@ -1526,8 +1551,8 @@ Func _GetAttributeEntry($Entry)
 ;			_ArrayDisplay($RUN_Clusters,"$RUN_Clusters")
 ;			_ArrayDisplay($RUN_VCN,"$RUN_VCN")
 			If $TotalClusters * $BytesPerCluster >= $Size Then
-;				ConsoleWrite(_ArrayToString($RUN_VCN) & @CRLF)
-;				ConsoleWrite(_ArrayToString($RUN_Clusters) & @CRLF)
+				ConsoleWrite(_ArrayToString($RUN_VCN) & @CRLF)
+				ConsoleWrite(_ArrayToString($RUN_Clusters) & @CRLF)
 ;ExtractFile
 				Local $nBytes
 				$hFile = _WinAPI_CreateFile($TargetDrive, 2, 6, 6)
@@ -1636,18 +1661,18 @@ Func _Get_IndexRoot($Entry,$Current_Attrib_Number,$CurrentAttributeName)
 EndFunc
 
 Func _StripIndxRecord($Entry)
-;	ConsoleWrite("Starting function _StripIndxRecord()" & @crlf)
+;~ 	ConsoleWrite("Starting function _StripIndxRecord()" & @crlf)
 	Local $LocalAttributeOffset = 1,$IndxHdrUpdateSeqArrOffset,$IndxHdrUpdateSeqArrSize,$IndxHdrUpdSeqArr,$IndxHdrUpdSeqArrPart0,$IndxHdrUpdSeqArrPart1,$IndxHdrUpdSeqArrPart2,$IndxHdrUpdSeqArrPart3,$IndxHdrUpdSeqArrPart4,$IndxHdrUpdSeqArrPart5,$IndxHdrUpdSeqArrPart6,$IndxHdrUpdSeqArrPart7,$IndxHdrUpdSeqArrPart8
 	Local $IndxRecordEnd1,$IndxRecordEnd2,$IndxRecordEnd3,$IndxRecordEnd4,$IndxRecordEnd5,$IndxRecordEnd6,$IndxRecordEnd7,$IndxRecordEnd8,$IndxRecordSize,$IndxHeaderSize,$IsNotLeafNode
-;	ConsoleWrite("Unfixed INDX record:" & @crlf)
+;~ 	ConsoleWrite("Unfixed INDX record:" & @crlf)
 ;	ConsoleWrite(_HexEncode("0x"&$Entry) & @crlf)
 ;	ConsoleWrite(_HexEncode("0x" & StringMid($Entry,1,4096)) & @crlf)
 	$IndxHdrUpdateSeqArrOffset = Dec(_SwapEndian(StringMid($Entry,$LocalAttributeOffset+8,4)))
-;	ConsoleWrite("$IndxHdrUpdateSeqArrOffset = " & $IndxHdrUpdateSeqArrOffset & @crlf)
+;~ 	ConsoleWrite("$IndxHdrUpdateSeqArrOffset = " & $IndxHdrUpdateSeqArrOffset & @crlf)
 	$IndxHdrUpdateSeqArrSize = Dec(_SwapEndian(StringMid($Entry,$LocalAttributeOffset+12,4)))
-;	ConsoleWrite("$IndxHdrUpdateSeqArrSize = " & $IndxHdrUpdateSeqArrSize & @crlf)
+;~ 	ConsoleWrite("$IndxHdrUpdateSeqArrSize = " & $IndxHdrUpdateSeqArrSize & @crlf)
 	$IndxHdrUpdSeqArr = StringMid($Entry,1+($IndxHdrUpdateSeqArrOffset*2),$IndxHdrUpdateSeqArrSize*2*2)
-;	ConsoleWrite("$IndxHdrUpdSeqArr = " & $IndxHdrUpdSeqArr & @crlf)
+;~ 	ConsoleWrite("$IndxHdrUpdSeqArr = " & $IndxHdrUpdSeqArr & @crlf)
 	$IndxHdrUpdSeqArrPart0 = StringMid($IndxHdrUpdSeqArr,1,4)
 	$IndxHdrUpdSeqArrPart1 = StringMid($IndxHdrUpdSeqArr,5,4)
 	$IndxHdrUpdSeqArrPart2 = StringMid($IndxHdrUpdSeqArr,9,4)
@@ -1672,32 +1697,32 @@ Func _StripIndxRecord($Entry)
 		$Entry = StringMid($Entry,1,1020) & $IndxHdrUpdSeqArrPart1 & StringMid($Entry,1025,1020) & $IndxHdrUpdSeqArrPart2 & StringMid($Entry,2049,1020) & $IndxHdrUpdSeqArrPart3 & StringMid($Entry,3073,1020) & $IndxHdrUpdSeqArrPart4 & StringMid($Entry,4097,1020) & $IndxHdrUpdSeqArrPart5 & StringMid($Entry,5121,1020) & $IndxHdrUpdSeqArrPart6 & StringMid($Entry,6145,1020) & $IndxHdrUpdSeqArrPart7 & StringMid($Entry,7169,1020)
 	EndIf
 	$IndxRecordSize = Dec(_SwapEndian(StringMid($Entry,$LocalAttributeOffset+56,8)),2)
-;	ConsoleWrite("$IndxRecordSize = " & $IndxRecordSize & @crlf)
+;~ 	ConsoleWrite("$IndxRecordSize = " & $IndxRecordSize & @crlf)
 	$IndxHeaderSize = Dec(_SwapEndian(StringMid($Entry,$LocalAttributeOffset+48,8)),2)
-;	ConsoleWrite("$IndxHeaderSize = " & $IndxHeaderSize & @crlf)
+;~ 	ConsoleWrite("$IndxHeaderSize = " & $IndxHeaderSize & @crlf)
 	$IsNotLeafNode = StringMid($Entry,$LocalAttributeOffset+72,2) ;1 if not leaf node
 	$Entry = StringMid($Entry,$LocalAttributeOffset+48+($IndxHeaderSize*2),($IndxRecordSize-$IndxHeaderSize-16)*2)
 	If $IsNotLeafNode = "01" Then  ; This flag leads to the entry being 8 bytes of 00's longer than the others. Can be stripped I think.
 		$Entry = StringTrimRight($Entry,16)
-;		ConsoleWrite("Is not leaf node..." & @crlf)
+		ConsoleWrite("Is not leaf node..." & @crlf)
 	EndIf
 	Return $Entry
 EndFunc
 
 Func _Get_IndexAllocation($Entry,$Current_Attrib_Number,$CurrentAttributeName)
-;	ConsoleWrite("Starting function _Get_IndexAllocation()" & @crlf)
+	ConsoleWrite("Starting function _Get_IndexAllocation()" & @crlf)
 	Local $NextPosition = 1,$IndxHdrMagic,$IndxEntries,$TotalIndxEntries
-;	ConsoleWrite("StringLen of chunk = " & StringLen($Entry) & @crlf)
-;	ConsoleWrite("Expected records = " & StringLen($Entry)/8192 & @crlf)
+	ConsoleWrite("StringLen of chunk = " & StringLen($Entry) & @crlf)
+	ConsoleWrite("Expected records = " & StringLen($Entry)/8192 & @crlf)
 	$NextPosition = 1
 	Do
 		$IndxHdrMagic = StringMid($Entry,$NextPosition,8)
-;		ConsoleWrite("$IndxHdrMagic = " & $IndxHdrMagic & @crlf)
+;~ 		ConsoleWrite("$IndxHdrMagic = " & $IndxHdrMagic & @crlf)
 		$IndxHdrMagic = _HexToString($IndxHdrMagic)
-;		ConsoleWrite("$IndxHdrMagic = " & $IndxHdrMagic & @crlf)
+;~ 		ConsoleWrite("$IndxHdrMagic = " & $IndxHdrMagic & @crlf)
 		If $IndxHdrMagic <> "INDX" Then
-;			ConsoleWrite("$IndxHdrMagic: " & $IndxHdrMagic & @crlf)
-;			ConsoleWrite("Error: Record is not of type INDX, and this was not expected.." & @crlf)
+			ConsoleWrite("$IndxHdrMagic: " & $IndxHdrMagic & @crlf)
+			ConsoleWrite("Error: Record is not of type INDX, and this was not expected.." & @crlf)
 			$NextPosition += 8192
 			ContinueLoop
 		EndIf
@@ -1705,18 +1730,21 @@ Func _Get_IndexAllocation($Entry,$Current_Attrib_Number,$CurrentAttributeName)
 		$TotalIndxEntries &= $IndxEntries
 		$NextPosition += 8192
 	Until $NextPosition >= StringLen($Entry)+32
-;	ConsoleWrite("INDX record:" & @crlf)
+	ConsoleWrite("INDX record:" & @crlf)
 ;	ConsoleWrite(_HexEncode("0x"& StringMid($Entry,1)) & @crlf)
-;	ConsoleWrite("Total chunk of stripped INDX entries:" & @crlf)
+	ConsoleWrite("Total chunk of stripped INDX entries:" & @crlf)
 ;	ConsoleWrite(_HexEncode("0x"& StringMid($TotalIndxEntries,1)) & @crlf)
 	_DecodeIndxEntries($TotalIndxEntries,$Current_Attrib_Number,$CurrentAttributeName)
+	ConsoleWrite("Exiting function _Get_IndexAllocation()" & @crlf)
 EndFunc
 
 Func _DecodeIndxEntries($Entry,$Current_Attrib_Number,$CurrentAttributeName)
-;	ConsoleWrite("Starting function _DecodeIndxEntries()" & @crlf)
+	ConsoleWrite("Starting function _DecodeIndxEntries()" & @crlf)
+	ConsoleWrite(_Now () & "." & _MSec() & @crlf)
 	Local $LocalAttributeOffset = 1,$NewLocalAttributeOffset,$IndxHdrMagic,$IndxHdrUpdateSeqArrOffset,$IndxHdrUpdateSeqArrSize,$IndxHdrLogFileSequenceNo,$IndxHdrVCNOfIndx,$IndxHdrOffsetToIndexEntries,$IndxHdrSizeOfIndexEntries,$IndxHdrAllocatedSizeOfIndexEntries
 	Local $IndxHdrFlag,$IndxHdrPadding,$IndxHdrUpdateSequence,$IndxHdrUpdSeqArr,$IndxHdrUpdSeqArrPart0,$IndxHdrUpdSeqArrPart1,$IndxHdrUpdSeqArrPart2,$IndxHdrUpdSeqArrPart3,$IndxRecordEnd4,$IndxRecordEnd1,$IndxRecordEnd2,$IndxRecordEnd3,$IndxRecordEnd4
 	Local $FileReference,$IndexEntryLength,$StreamLength,$Flags,$Stream,$SubNodeVCN,$tmp0=0,$tmp1=0,$tmp2=0,$tmp3=0,$EntryCounter=1,$Padding2,$EntryCounter=UBound($IndxFileNameArr)
+	ConsoleWrite("$EntryCounter: " & $EntryCounter & @crlf)
 	$NewLocalAttributeOffset = 1
 	$MFTReference = StringMid($Entry,$NewLocalAttributeOffset,12)
 	$MFTReference = StringMid($MFTReference,7,2)&StringMid($MFTReference,5,2)&StringMid($MFTReference,3,2)&StringMid($MFTReference,1,2)
@@ -1846,29 +1874,87 @@ Func _DecodeIndxEntries($Entry,$Current_Attrib_Number,$CurrentAttributeName)
 ; Work through the rest of the index entries
 	$NextEntryOffset = $NewLocalAttributeOffset+164+($Indx_NameLength*2*2)+$PaddingLength+$SubNodeVCNLength
 	If $NextEntryOffset+64 >= StringLen($Entry) Then Return
+	ConsoleWrite("$EntryCounter: " & $EntryCounter & @crlf)
+	ConsoleWrite("Before FAST DO LOOP: " & _Now () & "." & _MSec() & @crlf)
+;
+;
+;
+	$FastNextEntryOffset = $NextEntryOffset
+	$FastEntry = $Entry
+	$FastEntryCounter = $EntryCounter
+	Do
+		$FastEntryCounter += 1
+		$FastIndexFlags = StringMid($FastEntry,$FastNextEntryOffset+24,4)
+		$FastIndx_NameLength = StringMid($FastEntry,$FastNextEntryOffset+160,2)
+		$FastIndx_NameLength = Dec($FastIndx_NameLength)
+		$tmp0 = 0
+		$tmp2 = 0
+		$tmp3 = 0
+		$tmp1 = 164+($FastIndx_NameLength*2*2)
+		Do ; Calculate the length of the padding - 8 byte aligned
+			$tmp2 = $tmp1/16
+			If Not IsInt($tmp2) Then
+				$tmp0 = 2
+				$tmp1 += $tmp0
+				$tmp3 += $tmp0
+			EndIf
+		Until IsInt($tmp2)
+		$FastPaddingLength = $tmp3
+		If $FastIndexFlags <> "0000" Then
+			$FastSubNodeVCNLength = 16
+		Else
+			$FastSubNodeVCNLength = 0
+		EndIf
+		$FastNextEntryOffset = $FastNextEntryOffset+164+($FastIndx_NameLength*2*2)+$FastPaddingLength+$FastSubNodeVCNLength
+	Until $FastNextEntryOffset+32 >= StringLen($FastEntry)
+	ConsoleWrite("After FAST DO LOOP: " & _Now () & "." & _MSec() & @crlf)
+	ConsoleWrite("$FastEntryCounter: " & $FastEntryCounter & @crlf)
+;
+;
+;
+		ReDim $IndxEntryNumberArr[1+$FastEntryCounter]
+		ReDim $IndxMFTReferenceArr[1+$FastEntryCounter]
+		Redim $IndxMFTRefSeqNoArr[1+$FastEntryCounter]
+		ReDim $IndxIndexFlagsArr[1+$FastEntryCounter]
+		ReDim $IndxMFTReferenceOfParentArr[1+$FastEntryCounter]
+		ReDim $IndxMFTParentRefSeqNoArr[1+$FastEntryCounter]
+		ReDim $IndxCTimeArr[1+$FastEntryCounter]
+		ReDim $IndxATimeArr[1+$FastEntryCounter]
+		ReDim $IndxMTimeArr[1+$FastEntryCounter]
+		ReDim $IndxRTimeArr[1+$FastEntryCounter]
+		ReDim $IndxAllocSizeArr[1+$FastEntryCounter]
+		ReDim $IndxRealSizeArr[1+$FastEntryCounter]
+		ReDim $IndxFileFlagsArr[1+$FastEntryCounter]
+		ReDim $IndxFileNameArr[1+$FastEntryCounter]
+		ReDim $IndxNameSpaceArr[1+$FastEntryCounter]
+		ReDim $IndxSubNodeVCNArr[1+$FastEntryCounter]
+;
+;
+;
+	ConsoleWrite("Before DO LOOP: " & _Now () & "." & _MSec() & @crlf)
 	Do
 		$EntryCounter += 1
-;		ConsoleWrite("$EntryCounter = " & $EntryCounter & @crlf)
+;~ 		ConsoleWrite("$EntryCounter = " & $EntryCounter & @crlf)
 		$MFTReference = StringMid($Entry,$NextEntryOffset,12)
-;		ConsoleWrite("$MFTReference = " & $MFTReference & @crlf)
+;~ 		ConsoleWrite("$MFTReference = " & $MFTReference & @crlf)
 		$MFTReference = StringMid($MFTReference,7,2)&StringMid($MFTReference,5,2)&StringMid($MFTReference,3,2)&StringMid($MFTReference,1,2)
 ;		$MFTReference = StringMid($MFTReference,15,2)&StringMid($MFTReference,13,2)&StringMid($MFTReference,11,2)&StringMid($MFTReference,9,2)&StringMid($MFTReference,7,2)&StringMid($MFTReference,5,2)&StringMid($MFTReference,3,2)&StringMid($MFTReference,1,2)
-;		ConsoleWrite("$MFTReference = " & $MFTReference & @crlf)
+;~ 		ConsoleWrite("$MFTReference = " & $MFTReference & @crlf)
 		$MFTReference = Dec($MFTReference)
 		$MFTReferenceSeqNo = StringMid($Entry,$NextEntryOffset+12,4)
 		$MFTReferenceSeqNo = Dec(StringMid($MFTReferenceSeqNo,3,2)&StringMid($MFTReferenceSeqNo,1,2))
 		$IndexEntryLength = StringMid($Entry,$NextEntryOffset+16,4)
-;		ConsoleWrite("$IndexEntryLength = " & $IndexEntryLength & @crlf)
+;~ 		ConsoleWrite("$IndexEntryLength = " & $IndexEntryLength & @crlf)
 		$IndexEntryLength = Dec(StringMid($IndexEntryLength,3,2)&StringMid($IndexEntryLength,3,2))
-;		ConsoleWrite("$IndexEntryLength = " & $IndexEntryLength & @crlf)
+;~ 		ConsoleWrite("$IndexEntryLength = " & $IndexEntryLength & @crlf)
 		$OffsetToFileName = StringMid($Entry,$NextEntryOffset+20,4)
-;		ConsoleWrite("$OffsetToFileName = " & $OffsetToFileName & @crlf)
+;~ 		ConsoleWrite("$OffsetToFileName = " & $OffsetToFileName & @crlf)
 		$OffsetToFileName = Dec(StringMid($OffsetToFileName,3,2)&StringMid($OffsetToFileName,3,2))
-;		ConsoleWrite("$OffsetToFileName = " & $OffsetToFileName & @crlf)
+;~ 		ConsoleWrite("$OffsetToFileName = " & $OffsetToFileName & @crlf)
 		$IndexFlags = StringMid($Entry,$NextEntryOffset+24,4)
-;		ConsoleWrite("$IndexFlags = " & $IndexFlags & @crlf)
+;~ 		ConsoleWrite("$IndexFlags = " & $IndexFlags & @crlf)
 		$Padding = StringMid($Entry,$NextEntryOffset+28,4)
-;		ConsoleWrite("$Padding = " & $Padding & @crlf)
+;~ 		ConsoleWrite("$Padding = " & $Padding & @crlf)
 		$MFTReferenceOfParent = StringMid($Entry,$NextEntryOffset+32,12)
 ;		ConsoleWrite("$MFTReferenceOfParent = " & $MFTReferenceOfParent & @crlf)
 		$MFTReferenceOfParent = StringMid($MFTReferenceOfParent,7,2)&StringMid($MFTReferenceOfParent,5,2)&StringMid($MFTReferenceOfParent,3,2)&StringMid($MFTReferenceOfParent,1,2)
@@ -1878,32 +1964,32 @@ Func _DecodeIndxEntries($Entry,$Current_Attrib_Number,$CurrentAttributeName)
 		$MFTReferenceOfParentSeqNo = StringMid($Entry,$NextEntryOffset+44,4)
 		$MFTReferenceOfParentSeqNo = Dec(StringMid($MFTReferenceOfParentSeqNo,3,2) & StringMid($MFTReferenceOfParentSeqNo,3,2))
 
-		$Indx_CTime = StringMid($Entry,$NextEntryOffset+48,16)
-		$Indx_CTime = StringMid($Indx_CTime,15,2) & StringMid($Indx_CTime,13,2) & StringMid($Indx_CTime,11,2) & StringMid($Indx_CTime,9,2) & StringMid($Indx_CTime,7,2) & StringMid($Indx_CTime,5,2) & StringMid($Indx_CTime,3,2) & StringMid($Indx_CTime,1,2)
-		$Indx_CTime_tmp = _WinTime_UTCFileTimeToLocalFileTime("0x" & $Indx_CTime)
-		$Indx_CTime = _WinTime_UTCFileTimeFormat(Dec($Indx_CTime)-$tDelta,$DateTimeFormat,2)
-		$Indx_CTime = $Indx_CTime & ":" & _FillZero(StringRight($Indx_CTime_tmp,4))
+;~ 		$Indx_CTime = StringMid($Entry,$NextEntryOffset+48,16)
+;~ 		$Indx_CTime = StringMid($Indx_CTime,15,2) & StringMid($Indx_CTime,13,2) & StringMid($Indx_CTime,11,2) & StringMid($Indx_CTime,9,2) & StringMid($Indx_CTime,7,2) & StringMid($Indx_CTime,5,2) & StringMid($Indx_CTime,3,2) & StringMid($Indx_CTime,1,2)
+;~ 		$Indx_CTime_tmp = _WinTime_UTCFileTimeToLocalFileTime("0x" & $Indx_CTime)
+;~ 		$Indx_CTime = _WinTime_UTCFileTimeFormat(Dec($Indx_CTime)-$tDelta,$DateTimeFormat,2)
+;~ 		$Indx_CTime = $Indx_CTime & ":" & _FillZero(StringRight($Indx_CTime_tmp,4))
 ;		ConsoleWrite("$Indx_CTime = " & $Indx_CTime & @crlf)
 ;
-		$Indx_ATime = StringMid($Entry,$NextEntryOffset+64,16)
-		$Indx_ATime = StringMid($Indx_ATime,15,2) & StringMid($Indx_ATime,13,2) & StringMid($Indx_ATime,11,2) & StringMid($Indx_ATime,9,2) & StringMid($Indx_ATime,7,2) & StringMid($Indx_ATime,5,2) & StringMid($Indx_ATime,3,2) & StringMid($Indx_ATime,1,2)
-		$Indx_ATime_tmp = _WinTime_UTCFileTimeToLocalFileTime("0x" & $Indx_ATime)
-		$Indx_ATime = _WinTime_UTCFileTimeFormat(Dec($Indx_ATime)-$tDelta,$DateTimeFormat,2)
-		$Indx_ATime = $Indx_ATime & ":" & _FillZero(StringRight($Indx_ATime_tmp,4))
+;~ 		$Indx_ATime = StringMid($Entry,$NextEntryOffset+64,16)
+;~ 		$Indx_ATime = StringMid($Indx_ATime,15,2) & StringMid($Indx_ATime,13,2) & StringMid($Indx_ATime,11,2) & StringMid($Indx_ATime,9,2) & StringMid($Indx_ATime,7,2) & StringMid($Indx_ATime,5,2) & StringMid($Indx_ATime,3,2) & StringMid($Indx_ATime,1,2)
+;~ 		$Indx_ATime_tmp = _WinTime_UTCFileTimeToLocalFileTime("0x" & $Indx_ATime)
+;~ 		$Indx_ATime = _WinTime_UTCFileTimeFormat(Dec($Indx_ATime)-$tDelta,$DateTimeFormat,2)
+;~ 		$Indx_ATime = $Indx_ATime & ":" & _FillZero(StringRight($Indx_ATime_tmp,4))
 ;		ConsoleWrite("$Indx_ATime = " & $Indx_ATime & @crlf)
 ;
-		$Indx_MTime = StringMid($Entry,$NextEntryOffset+80,16)
-		$Indx_MTime = StringMid($Indx_MTime,15,2) & StringMid($Indx_MTime,13,2) & StringMid($Indx_MTime,11,2) & StringMid($Indx_MTime,9,2) & StringMid($Indx_MTime,7,2) & StringMid($Indx_MTime,5,2) & StringMid($Indx_MTime,3,2) & StringMid($Indx_MTime,1,2)
-		$Indx_MTime_tmp = _WinTime_UTCFileTimeToLocalFileTime("0x" & $Indx_MTime)
-		$Indx_MTime = _WinTime_UTCFileTimeFormat(Dec($Indx_MTime)-$tDelta,$DateTimeFormat,2)
-		$Indx_MTime = $Indx_MTime & ":" & _FillZero(StringRight($Indx_MTime_tmp,4))
+;~ 		$Indx_MTime = StringMid($Entry,$NextEntryOffset+80,16)
+;~ 		$Indx_MTime = StringMid($Indx_MTime,15,2) & StringMid($Indx_MTime,13,2) & StringMid($Indx_MTime,11,2) & StringMid($Indx_MTime,9,2) & StringMid($Indx_MTime,7,2) & StringMid($Indx_MTime,5,2) & StringMid($Indx_MTime,3,2) & StringMid($Indx_MTime,1,2)
+;~ 		$Indx_MTime_tmp = _WinTime_UTCFileTimeToLocalFileTime("0x" & $Indx_MTime)
+;~ 		$Indx_MTime = _WinTime_UTCFileTimeFormat(Dec($Indx_MTime)-$tDelta,$DateTimeFormat,2)
+;~ 		$Indx_MTime = $Indx_MTime & ":" & _FillZero(StringRight($Indx_MTime_tmp,4))
 ;		ConsoleWrite("$Indx_MTime = " & $Indx_MTime & @crlf)
 ;
-		$Indx_RTime = StringMid($Entry,$NextEntryOffset+96,16)
-		$Indx_RTime = StringMid($Indx_RTime,15,2) & StringMid($Indx_RTime,13,2) & StringMid($Indx_RTime,11,2) & StringMid($Indx_RTime,9,2) & StringMid($Indx_RTime,7,2) & StringMid($Indx_RTime,5,2) & StringMid($Indx_RTime,3,2) & StringMid($Indx_RTime,1,2)
-		$Indx_RTime_tmp = _WinTime_UTCFileTimeToLocalFileTime("0x" & $Indx_RTime)
-		$Indx_RTime = _WinTime_UTCFileTimeFormat(Dec($Indx_RTime)-$tDelta,$DateTimeFormat,2)
-		$Indx_RTime = $Indx_RTime & ":" & _FillZero(StringRight($Indx_RTime_tmp,4))
+;~ 		$Indx_RTime = StringMid($Entry,$NextEntryOffset+96,16)
+;~ 		$Indx_RTime = StringMid($Indx_RTime,15,2) & StringMid($Indx_RTime,13,2) & StringMid($Indx_RTime,11,2) & StringMid($Indx_RTime,9,2) & StringMid($Indx_RTime,7,2) & StringMid($Indx_RTime,5,2) & StringMid($Indx_RTime,3,2) & StringMid($Indx_RTime,1,2)
+;~ 		$Indx_RTime_tmp = _WinTime_UTCFileTimeToLocalFileTime("0x" & $Indx_RTime)
+;~ 		$Indx_RTime = _WinTime_UTCFileTimeFormat(Dec($Indx_RTime)-$tDelta,$DateTimeFormat,2)
+;~ 		$Indx_RTime = $Indx_RTime & ":" & _FillZero(StringRight($Indx_RTime_tmp,4))
 ;		ConsoleWrite("$Indx_RTime = " & $Indx_RTime & @crlf)
 ;
 		$Indx_AllocSize = StringMid($Entry,$NextEntryOffset+112,16)
@@ -1923,7 +2009,7 @@ Func _DecodeIndxEntries($Entry,$Current_Attrib_Number,$CurrentAttributeName)
 		$Indx_NameLength = Dec($Indx_NameLength)
 ;		ConsoleWrite("$Indx_NameLength = " & $Indx_NameLength & @crlf)
 		$Indx_NameSpace = StringMid($Entry,$NextEntryOffset+162,2)
-;		ConsoleWrite("$Indx_NameSpace = " & $Indx_NameSpace & @crlf)
+;~ 		ConsoleWrite("$Indx_NameSpace = " & $Indx_NameSpace & @crlf)
 		Select
 			Case $Indx_NameSpace = "00"	;POSIX
 				$Indx_NameSpace = "POSIX"
@@ -1935,9 +2021,9 @@ Func _DecodeIndxEntries($Entry,$Current_Attrib_Number,$CurrentAttributeName)
 				$Indx_NameSpace = "DOS+WIN32"
 		EndSelect
 		$Indx_FileName = StringMid($Entry,$NextEntryOffset+164,$Indx_NameLength*2*2)
-;		ConsoleWrite("$Indx_FileName = " & $Indx_FileName & @crlf)
+;~ 		ConsoleWrite("$Indx_FileName = " & $Indx_FileName & @crlf)
 		$Indx_FileName = _UnicodeHexToStr($Indx_FileName)
-;		ConsoleWrite("$Indx_FileName = " & $Indx_FileName & @crlf)
+;~ 		ConsoleWrite("$Indx_FileName = " & $Indx_FileName & @crlf)
 		$tmp0 = 0
 		$tmp2 = 0
 		$tmp3 = 0
@@ -1951,9 +2037,9 @@ Func _DecodeIndxEntries($Entry,$Current_Attrib_Number,$CurrentAttributeName)
 			EndIf
 		Until IsInt($tmp2)
 		$PaddingLength = $tmp3
-;		ConsoleWrite("$PaddingLength = " & $PaddingLength & @crlf)
+;~ 		ConsoleWrite("$PaddingLength = " & $PaddingLength & @crlf)
 		$Padding = StringMid($Entry,$NextEntryOffset+164+($Indx_NameLength*2*2),$PaddingLength)
-;		ConsoleWrite("$Padding = " & $Padding & @crlf)
+;~ 		ConsoleWrite("$Padding = " & $Padding & @crlf)
 		If $IndexFlags <> "0000" Then
 			$SubNodeVCN = StringMid($Entry,$NextEntryOffset+164+($Indx_NameLength*2*2)+$PaddingLength,16)
 			$SubNodeVCNLength = 16
@@ -1961,34 +2047,34 @@ Func _DecodeIndxEntries($Entry,$Current_Attrib_Number,$CurrentAttributeName)
 			$SubNodeVCN = ""
 			$SubNodeVCNLength = 0
 		EndIf
-;		ConsoleWrite("$SubNodeVCN = " & $SubNodeVCN & @crlf)
+;~ 		ConsoleWrite("$SubNodeVCN = " & $SubNodeVCN & @crlf)
 		$NextEntryOffset = $NextEntryOffset+164+($Indx_NameLength*2*2)+$PaddingLength+$SubNodeVCNLength
-		ReDim $IndxEntryNumberArr[1+$EntryCounter]
-		ReDim $IndxMFTReferenceArr[1+$EntryCounter]
-		Redim $IndxMFTRefSeqNoArr[1+$EntryCounter]
-		ReDim $IndxIndexFlagsArr[1+$EntryCounter]
-		ReDim $IndxMFTReferenceOfParentArr[1+$EntryCounter]
-		ReDim $IndxMFTParentRefSeqNoArr[1+$EntryCounter]
-		ReDim $IndxCTimeArr[1+$EntryCounter]
-		ReDim $IndxATimeArr[1+$EntryCounter]
-		ReDim $IndxMTimeArr[1+$EntryCounter]
-		ReDim $IndxRTimeArr[1+$EntryCounter]
-		ReDim $IndxAllocSizeArr[1+$EntryCounter]
-		ReDim $IndxRealSizeArr[1+$EntryCounter]
-		ReDim $IndxFileFlagsArr[1+$EntryCounter]
-		ReDim $IndxFileNameArr[1+$EntryCounter]
-		ReDim $IndxNameSpaceArr[1+$EntryCounter]
-		ReDim $IndxSubNodeVCNArr[1+$EntryCounter]
+;~ 		ReDim $IndxEntryNumberArr[1+$EntryCounter]
+;~ 		ReDim $IndxMFTReferenceArr[1+$EntryCounter]
+;~ 		Redim $IndxMFTRefSeqNoArr[1+$EntryCounter]
+;~ 		ReDim $IndxIndexFlagsArr[1+$EntryCounter]
+;~ 		ReDim $IndxMFTReferenceOfParentArr[1+$EntryCounter]
+;~ 		ReDim $IndxMFTParentRefSeqNoArr[1+$EntryCounter]
+;~ 		ReDim $IndxCTimeArr[1+$EntryCounter]
+;~ 		ReDim $IndxATimeArr[1+$EntryCounter]
+;~ 		ReDim $IndxMTimeArr[1+$EntryCounter]
+;~ 		ReDim $IndxRTimeArr[1+$EntryCounter]
+;~ 		ReDim $IndxAllocSizeArr[1+$EntryCounter]
+;~ 		ReDim $IndxRealSizeArr[1+$EntryCounter]
+;~ 		ReDim $IndxFileFlagsArr[1+$EntryCounter]
+;~ 		ReDim $IndxFileNameArr[1+$EntryCounter]
+;~ 		ReDim $IndxNameSpaceArr[1+$EntryCounter]
+;~ 		ReDim $IndxSubNodeVCNArr[1+$EntryCounter]
 		$IndxEntryNumberArr[$EntryCounter] = $EntryCounter
 		$IndxMFTReferenceArr[$EntryCounter] = $MFTReference
 		$IndxMFTRefSeqNoArr[$EntryCounter] = $MFTReferenceSeqNo
 		$IndxIndexFlagsArr[$EntryCounter] = $IndexFlags
 		$IndxMFTReferenceOfParentArr[$EntryCounter] = $MFTReferenceOfParent
 		$IndxMFTParentRefSeqNoArr[$EntryCounter] = $MFTReferenceOfParentSeqNo
-		$IndxCTimeArr[$EntryCounter] = $Indx_CTime
-		$IndxATimeArr[$EntryCounter] = $Indx_ATime
-		$IndxMTimeArr[$EntryCounter] = $Indx_MTime
-		$IndxRTimeArr[$EntryCounter] = $Indx_RTime
+;~ 		$IndxCTimeArr[$EntryCounter] = $Indx_CTime
+;~ 		$IndxATimeArr[$EntryCounter] = $Indx_ATime
+;~ 		$IndxMTimeArr[$EntryCounter] = $Indx_MTime
+;~ 		$IndxRTimeArr[$EntryCounter] = $Indx_RTime
 		$IndxAllocSizeArr[$EntryCounter] = $Indx_AllocSize
 		$IndxRealSizeArr[$EntryCounter] = $Indx_RealSize
 		$IndxFileFlagsArr[$EntryCounter] = $Indx_File_Flags
@@ -1997,6 +2083,21 @@ Func _DecodeIndxEntries($Entry,$Current_Attrib_Number,$CurrentAttributeName)
 		$IndxSubNodeVCNArr[$EntryCounter] = $SubNodeVCN
 ;		_ArrayDisplay($IndxFileNameArr,"$IndxFileNameArr")
 	Until $NextEntryOffset+32 >= StringLen($Entry)
+	ConsoleWrite("After DO LOOP: " & _Now () & "." & _MSec() & @crlf)
+	ConsoleWrite("$EntryCounter: " & $EntryCounter & @crlf)
+	ConsoleWrite("Exiting function _DecodeIndxEntries()" & @crlf)
+	ConsoleWrite(_Now () & "." & _MSec() & @crlf)
+EndFunc
+
+Func _MSec()
+    Local $stSystemTime = DllStructCreate('ushort;ushort;ushort;ushort;ushort;ushort;ushort;ushort')
+    DllCall('kernel32.dll', 'none', 'GetSystemTime', 'ptr', DllStructGetPtr($stSystemTime))
+
+    $sMilliSeconds = StringFormat('%03d', DllStructGetData($stSystemTime, 8))
+
+    $stSystemTime = 0
+
+    Return $sMilliSeconds
 EndFunc
 
 Func _SetArrays()
@@ -2239,7 +2340,7 @@ Func _GetRunsFromAttributeListMFT0()
 	For $i = 1 To UBound($DataQ) - 1
 		_DecodeDataQEntry($DataQ[$i])
 		If $NonResidentFlag = '00' Then
-;			ConsoleWrite("Resident" & @CRLF)
+			ConsoleWrite("Resident" & @CRLF)
 		Else
 			Global $RUN_VCN[1], $RUN_Clusters[1]
 			$TotalClusters = $Data_Clusters
@@ -2360,7 +2461,7 @@ Func _GenRefArray()
 	$ref = -1
 	$begin = TimerInit()
 	For $r = 1 To Ubound($MFT_RUN_VCN)-1
-;		ConsoleWrite("$r: " & $r & @CRLF)
+		ConsoleWrite("$r: " & $r & @CRLF)
 		$DoKeepCluster=$MFTClustersToKeep
 		$MFTClustersToKeep = Mod($MFT_RUN_Clusters[$r]+($ClustersPerFileRecordSegment-$MFTClustersToKeep),$ClustersPerFileRecordSegment)
 		If $MFTClustersToKeep <> 0 Then
@@ -2407,7 +2508,7 @@ EndFunc
 Func _GetInputParams()
 	Local $TmpAllAttr, $TmpOutPath, $TmpImageFile, $TmpFileNamePath, $TmpImageVolume, $TmpRawDirMode, $TmpWriteFSInfo, $str1,$str2,$pos,$matchstr
 	For $i = 1 To $cmdline[0]
-		;ConsoleWrite("Param " & $i & ": " & $cmdline[$i] & @CRLF)
+		ConsoleWrite("Param " & $i & ": " & $cmdline[$i] & @CRLF)
 		If StringLeft($cmdline[$i],14) = "/FileNamePath:" Then $TmpFileNamePath = StringMid($cmdline[$i],15)
 		If StringLeft($cmdline[$i],12) = "/OutputPath:" Then $TmpOutPath = StringMid($cmdline[$i],13)
 		If StringLeft($cmdline[$i],9) = "/AllAttr:" Then $TmpAllAttr = StringMid($cmdline[$i],10)
@@ -2489,7 +2590,7 @@ Func _GetInputParams()
 				EndIf
 				$ImageOffset = $VolumesArray[$TmpImageVolume][1]
 				$TargetDrive = $TargetImageFile
-				;ConsoleWrite("$Entries: " & $Entries & @CRLF)
+				ConsoleWrite("$Entries: " & $Entries & @CRLF)
 				;_ArrayDisplay($VolumesArray,"$VolumesArray")
 			EndIf
 		Else
@@ -2551,7 +2652,7 @@ Func _GetInputParams()
 				EndIf
 				$ImageOffset = $VolumesArray[$TmpImageVolume][1]
 				$TargetDrive = $TargetImageFile
-				;ConsoleWrite("$Entries: " & $Entries & @CRLF)
+				ConsoleWrite("$Entries: " & $Entries & @CRLF)
 				;_ArrayDisplay($VolumesArray,"$VolumesArray")
 			EndIf
 		EndIf
@@ -2625,7 +2726,7 @@ Func _GetInputParams()
 				If StringMid($TmpFileNamePath,1,1) = "\" Then $TmpFileNamePath = "x:" & $TmpFileNamePath
 				If StringMid($TmpFileNamePath,2,1) = ":" Then
 					If Not StringIsDigit(StringMid($TmpFileNamePath,3)) Then
-						;ConsoleWrite("Error: File not found in FileNamePath: " & $TmpFileNamePath & @CRLF)
+						ConsoleWrite("Error: File not found in FileNamePath: " & $TmpFileNamePath & @CRLF)
 						$TargetFileName = $TmpFileNamePath
 					Else
 						$IndexNumber = StringMid($TmpFileNamePath,3)
@@ -2692,7 +2793,7 @@ Func _CheckMBR($TargetImageFile)
 	Local $read = _WinAPI_ReadFile($hImage, DllStructGetPtr($tBuffer), 512, $nBytes)
 	If $read = 0 Then Return ""
 	Local $sector = DllStructGetData($tBuffer, 1)
-	;ConsoleWrite(_HexEncode($sector) & @CRLF)
+	ConsoleWrite(_HexEncode($sector) & @CRLF)
 	For $PartitionNumber = 0 To 3
 		$PartitionEntry = StringMid($sector,($PartitionNumber*32)+3+892,32)
 		If $PartitionEntry = "00000000000000000000000000000000" Then ExitLoop ; No more entries
@@ -2724,7 +2825,7 @@ EndFunc   ;==>_CheckMBR
 
 Func _CheckGPT($hImage) ; Assume GPT to be present at sector 1, which is not fool proof
    ;Actually it is. While LBA1 may not be at sector 1 on the disk, it will always be there in an image.
-   ;ConsoleWrite("_CheckGPT()" & @CRLF)
+   ConsoleWrite("_CheckGPT()" & @CRLF)
 	Local $nbytes,$read,$sector,$GPTSignature,$StartLBA,$Processed=0,$FirstLBA,$LastLBA
 	$tBuffer = DllStructCreate("byte[512]")
 	$read = _WinAPI_ReadFile($hImage, DllStructGetPtr($tBuffer), 512, $nBytes)		;read second sector
@@ -2775,7 +2876,7 @@ Func _CheckExtendedPartition($StartSector, $hImage)	;Extended partitions can onl
 		$read = _WinAPI_ReadFile($hImage, DllStructGetPtr($tBuffer), 512, $nBytes)
 		If $read = 0 Then Return ""
 		$sector = DllStructGetData($tBuffer, 1)
-		;ConsoleWrite(_HexEncode($sector) & @CRLF)
+		ConsoleWrite(_HexEncode($sector) & @CRLF)
 		$PartitionTable = StringMid($sector,3+892,64)
 		$FilesystemDescriptor = StringMid($PartitionTable,9,2)
 		$StartingSector = $StartSector+$NextEntry+Dec(_SwapEndian(StringMid($PartitionTable,17,8)),2)
@@ -2878,7 +2979,7 @@ Func _DisplayList($DirListPath)
 				ConsoleWrite(@CRLF)
 			Next
 		Else
-;			ConsoleWrite("Error: There was no index found for the parent folder." & @CRLF)
+			ConsoleWrite("Error: There was no index found for the parent folder." & @CRLF)
 			Return SetError(1,0,0)
 		EndIf
 	ElseIf $DetailMode = 2 Then
@@ -2925,7 +3026,7 @@ Func _DisplayList($DirListPath)
 				ConsoleWrite($TextOut & @CRLF)
 			Next
 		Else
-;			ConsoleWrite("Error: There was no index found for the parent folder." & @CRLF)
+			ConsoleWrite("Error: There was no index found for the parent folder." & @CRLF)
 			Return SetError(1,0,0)
 		EndIf
 	EndIf
@@ -2949,7 +3050,7 @@ Func _ParseIndex($TestName)
 			EndIf
 		Next
 	Else
-;		ConsoleWrite("Error: No index found for: " & $TestName & @CRLF)
+		ConsoleWrite("Error: No index found for: " & $TestName & @CRLF)
 		Return SetError(1,0,0)
 	EndIf
 EndFunc


### PR DESCRIPTION
Changed logic: don't call DisplayList to trigger error
if you know upfront that MFTEntry is not directory.
This logic will just trigger going through directory one level up of file in full path
and in case of thousand of files DecodeIndexEntries can take significant
CPU load and duration of many seconds even after optimization of DecodeIndexEntries.

Check if there are atributes of $INDEX_ROOT or $INDEX_ALLOCATION present
if they are present only then asume that current level is not file
and that is possible that it is a directory which can be then
printed as with option /RawDirMode with three directory listing modes.
Note that $NextRef is not set at all in this branch of code
which is used for final file extraction.